### PR TITLE
Allow user to better control threads

### DIFF
--- a/streams.go
+++ b/streams.go
@@ -22,10 +22,7 @@ func (app *Application) StartStreams() {
 
 // StartStream starts single video stream
 func (app *Application) StartStream(k uuid.UUID) {
-	url, supportedTypes := app.Streams.GetStream(k)
-
-	hlsEnabled := typeExists("hls", supportedTypes)
-	go app.startLoop(context.Background(), k, url, hlsEnabled)
+	go app.RunStream(context.Background(), k)
 }
 
 func (app *Application) RunStream(ctx context.Context, k uuid.UUID) {

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -17,6 +17,13 @@ func NewStreamsStorageDefault() *StreamsStorage {
 	return &StreamsStorage{Streams: make(map[uuid.UUID]*StreamConfiguration)}
 }
 
+func (sm *StreamsStorage) GetStream(id uuid.UUID) (string, []string) {
+	sm.Lock()
+	defer sm.Unlock()
+
+	return sm.Streams[id].URL, sm.Streams[id].SupportedStreamTypes
+}
+
 // getKeys returns all storage streams' keys as slice
 func (sm *StreamsStorage) getKeys() []uuid.UUID {
 	sm.Lock()


### PR DESCRIPTION
I wanted to propose a new blocking method to run the Stream loop.

This blocking method allows us to pull out the go routines into the caller's code so that the caller can control startup, and shutdown for it's own methods. In my case, I wanted to split out the file generator from the api, but once those services were split I needed to be able to be able to wait for the process / be able to shut it down


Really like the abstractions, thank you for the code :)