### PR TITLE
Lock problem

### DIFF
--- a/application.go
+++ b/application.go
@@ -183,6 +183,9 @@ func (app *Application) setCors(cfg configuration.CORSConfiguration) {
 }
 
 func (app *Application) startHlsCast(streamID uuid.UUID, stopCast chan StopSignal) error {
+	if RWMutexLocked(&app.Streams.RWMutex) {
+		log.Warn().Str("fn", "startHlsCast").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	app.Streams.Lock()
 	defer app.Streams.Unlock()
 	stream, ok := app.Streams.store[streamID]
@@ -201,6 +204,9 @@ func (app *Application) startHlsCast(streamID uuid.UUID, stopCast chan StopSigna
 func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uuid.UUID, stopCast chan StopSignal, streamVerboseLevel VerboseLevel) error {
 	if archive == nil {
 		return ErrNullArchive
+	}
+	if RWMutexLocked(&app.Streams.RWMutex) {
+		log.Warn().Str("fn", "startMP4Cast").Str("stream_id", streamID.String()).Msg("Locked already")
 	}
 	app.Streams.Lock()
 	defer app.Streams.Unlock()

--- a/application.go
+++ b/application.go
@@ -10,7 +10,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pkg/errors"
 
-	"github.com/deepch/vdk/av"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
@@ -180,46 +179,4 @@ func (app *Application) setCors(cfg configuration.CORSConfiguration) {
 			}
 		}
 	}
-}
-
-func (app *Application) startHlsCast(streamID uuid.UUID, stopCast chan StopSignal) error {
-	if RWMutexLocked(&app.Streams.RWMutex) {
-		log.Warn().Str("fn", "startHlsCast").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
-	app.Streams.Lock()
-	defer app.Streams.Unlock()
-	stream, ok := app.Streams.store[streamID]
-	if !ok {
-		return ErrStreamNotFound
-	}
-	go func(id uuid.UUID, hlsChanel chan av.Packet, stop chan StopSignal) {
-		err := app.startHls(id, hlsChanel, stop)
-		if err != nil {
-			log.Error().Err(err).Str("scope", SCOPE_HLS).Str("event", EVENT_HLS_START_CAST).Str("stream_id", id.String()).Msg("Error on HLS cast start")
-		}
-	}(streamID, stream.hlsChanel, stopCast)
-	return nil
-}
-
-func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uuid.UUID, stopCast chan StopSignal, streamVerboseLevel VerboseLevel) error {
-	if archive == nil {
-		return ErrNullArchive
-	}
-	if RWMutexLocked(&app.Streams.RWMutex) {
-		log.Warn().Str("fn", "startMP4Cast").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
-	app.Streams.Lock()
-	defer app.Streams.Unlock()
-	stream, ok := app.Streams.store[streamID]
-	if !ok {
-		return ErrStreamNotFound
-	}
-	channel := stream.mp4Chanel
-	go func(arch *StreamArchiveWrapper, id uuid.UUID, mp4Chanel chan av.Packet, stop chan StopSignal, verbose VerboseLevel) {
-		err := app.startMP4(arch, id, mp4Chanel, stop, verbose)
-		if err != nil {
-			log.Error().Err(err).Str("scope", SCOPE_ARCHIVE).Str("event", EVENT_ARCHIVE_START_CAST).Str("stream_id", id.String()).Msg("Error on MP4 cast start")
-		}
-	}(archive, streamID, channel, stopCast, streamVerboseLevel)
-	return nil
 }

--- a/application.go
+++ b/application.go
@@ -182,14 +182,14 @@ func (app *Application) setCors(cfg configuration.CORSConfiguration) {
 	}
 }
 
-func (app *Application) startHlsCast(streamID uuid.UUID, stopCast chan bool) error {
+func (app *Application) startHlsCast(streamID uuid.UUID, stopCast chan StopSignal) error {
 	app.Streams.Lock()
 	defer app.Streams.Unlock()
 	stream, ok := app.Streams.store[streamID]
 	if !ok {
 		return ErrStreamNotFound
 	}
-	go func(id uuid.UUID, hlsChanel chan av.Packet, stop chan bool) {
+	go func(id uuid.UUID, hlsChanel chan av.Packet, stop chan StopSignal) {
 		err := app.startHls(id, hlsChanel, stop)
 		if err != nil {
 			log.Error().Err(err).Str("scope", SCOPE_HLS).Str("event", EVENT_HLS_START_CAST).Str("stream_id", id.String()).Msg("Error on HLS cast start")
@@ -198,7 +198,7 @@ func (app *Application) startHlsCast(streamID uuid.UUID, stopCast chan bool) err
 	return nil
 }
 
-func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uuid.UUID, stopCast chan bool, streamVerboseLevel VerboseLevel) error {
+func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uuid.UUID, stopCast chan StopSignal, streamVerboseLevel VerboseLevel) error {
 	if archive == nil {
 		return ErrNullArchive
 	}
@@ -209,7 +209,7 @@ func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uui
 		return ErrStreamNotFound
 	}
 	channel := stream.mp4Chanel
-	go func(arch *StreamArchiveWrapper, id uuid.UUID, mp4Chanel chan av.Packet, stop chan bool, verbose VerboseLevel) {
+	go func(arch *StreamArchiveWrapper, id uuid.UUID, mp4Chanel chan av.Packet, stop chan StopSignal, verbose VerboseLevel) {
 		err := app.startMP4(arch, id, mp4Chanel, stop, verbose)
 		if err != nil {
 			log.Error().Err(err).Str("scope", SCOPE_ARCHIVE).Str("event", EVENT_ARCHIVE_START_CAST).Str("stream_id", id.String()).Msg("Error on MP4 cast start")

--- a/cmd/video_server/main.go
+++ b/cmd/video_server/main.go
@@ -29,7 +29,7 @@ var (
 )
 
 func init() {
-	zerolog.TimeFieldFormat = time.RFC3339
+	zerolog.TimeFieldFormat = time.RFC3339Nano
 	zerolog.DurationFieldUnit = time.Second
 }
 

--- a/cmd/video_server/main.go
+++ b/cmd/video_server/main.go
@@ -30,6 +30,7 @@ var (
 
 func init() {
 	zerolog.TimeFieldFormat = time.RFC3339
+	zerolog.DurationFieldUnit = time.Second
 }
 
 func main() {

--- a/hls.go
+++ b/hls.go
@@ -16,7 +16,7 @@ import (
 )
 
 // startHls starts routine to create m3u8 playlists
-func (app *Application) startHls(streamID uuid.UUID, ch chan av.Packet, stopCast chan bool) error {
+func (app *Application) startHls(streamID uuid.UUID, ch chan av.Packet, stopCast chan StopSignal) error {
 	err := ensureDir(app.HLS.Directory)
 	if err != nil {
 		return errors.Wrap(err, "Can't create directory for HLS temporary files")

--- a/http_server.go
+++ b/http_server.go
@@ -145,6 +145,9 @@ func EnableCamera(app *Application, verboseLevel VerboseLevel) func(ctx *gin.Con
 				}
 				outputTypes = append(outputTypes, typ)
 			}
+			if RWMutexLocked(&app.Streams.RWMutex) {
+				log.Warn().Str("fn", "EnableCamera").Str("stream_id", postData.GUID.String()).Msg("RLocked already")
+			}
 			app.Streams.Lock()
 			app.Streams.store[postData.GUID] = NewStreamConfiguration(postData.URL, outputTypes)
 			app.Streams.Unlock()
@@ -170,6 +173,9 @@ func DisableCamera(app *Application, verboseLevel VerboseLevel) func(ctx *gin.Co
 			return
 		}
 		if exist := app.Streams.StreamExists(postData.GUID); exist {
+			if RWMutexLocked(&app.Streams.RWMutex) {
+				log.Warn().Str("fn", "DisableCamera").Str("stream_id", postData.GUID.String()).Msg("RLocked already")
+			}
 			app.Streams.Lock()
 			delete(app.Streams.store, postData.GUID)
 			app.Streams.Unlock()

--- a/http_server.go
+++ b/http_server.go
@@ -145,9 +145,6 @@ func EnableCamera(app *Application, verboseLevel VerboseLevel) func(ctx *gin.Con
 				}
 				outputTypes = append(outputTypes, typ)
 			}
-			if RWMutexLocked(&app.Streams.RWMutex) {
-				log.Warn().Str("fn", "EnableCamera").Str("stream_id", postData.GUID.String()).Msg("RLocked already")
-			}
 			app.Streams.Lock()
 			app.Streams.store[postData.GUID] = NewStreamConfiguration(postData.URL, outputTypes)
 			app.Streams.Unlock()
@@ -173,9 +170,6 @@ func DisableCamera(app *Application, verboseLevel VerboseLevel) func(ctx *gin.Co
 			return
 		}
 		if exist := app.Streams.StreamExists(postData.GUID); exist {
-			if RWMutexLocked(&app.Streams.RWMutex) {
-				log.Warn().Str("fn", "DisableCamera").Str("stream_id", postData.GUID.String()).Msg("RLocked already")
-			}
 			app.Streams.Lock()
 			delete(app.Streams.store, postData.GUID)
 			app.Streams.Unlock()

--- a/logger.go
+++ b/logger.go
@@ -28,6 +28,7 @@ const (
 	EVENT_STREAMING_STATUS_UPDATE       = "streaming_status_update"
 	EVENT_STREAMING_PACKET_SIGNAL       = "streaming_packet_signal"
 	EVENT_STREAMING_STOP_SIGNAL         = "streaming_stop_signal"
+	EVENT_STREAMING_UNKNOWN_SIGNAL      = "streaming_unknown_signal"
 	EVENT_STREAMING_CODEC_UPDATE_SIGNAL = "streaming_codec_update_signal"
 	EVENT_STREAMING_EXIT_SIGNAL         = "streaming_codec_exit_signal"
 	EVENT_STREAMING_CODEC_MET           = "streaming_codec_met"

--- a/mp4.go
+++ b/mp4.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (app *Application) startMP4(archive *StreamArchiveWrapper, streamID uuid.UUID, ch chan av.Packet, stopCast chan bool, streamVerboseLevel VerboseLevel) error {
+func (app *Application) startMP4(archive *StreamArchiveWrapper, streamID uuid.UUID, ch chan av.Packet, stopCast chan StopSignal, streamVerboseLevel VerboseLevel) error {
 	if archive == nil {
 		return ErrNullArchive
 	}
@@ -143,15 +143,15 @@ func processingMP4(
 	msPerSegment int64,
 	tsMuxer *mp4.Muxer,
 	ch chan av.Packet,
-	stopCast chan bool,
+	stopCast chan StopSignal,
 	streamVerboseLevel VerboseLevel,
 ) (av.Packet, time.Duration, bool, error) {
 	for {
 		select {
-		case <-stopCast:
+		case sig := <-stopCast:
 			isConnected = false
 			if streamVerboseLevel > VERBOSE_NONE {
-				log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_CHAN_STOP).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Stop cast signal")
+				log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_CHAN_STOP).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Any("stop_signal", sig).Msg("Stop cast signal")
 			}
 			return lastKeyFrame, lastPacketTime, isConnected, nil
 		case pck := <-ch:

--- a/mp4.go
+++ b/mp4.go
@@ -204,6 +204,9 @@ func processingMP4(
 					packetLength = pck.Time - lastPacketTime
 					lastPacketTime = pck.Time
 					if packetLength.Milliseconds() > msPerSegment { // If comment this you get [0; keyframe time] interval for the very first video file
+						if streamVerboseLevel > VERBOSE_NONE {
+							log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_WRITE).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Very first interval")
+						}
 						continue
 					}
 					segmentLength += packetLength
@@ -211,7 +214,7 @@ func processingMP4(
 				segmentCount++
 			} else {
 				if streamVerboseLevel > VERBOSE_ADD {
-					log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_WRITE).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Dur("pck_time", pck.Time).Dur("prev_pck_time", lastPacketTime).Msg("Current packet time < previous")
+					log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_WRITE).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Dur("pck_time", pck.Time).Dur("prev_pck_time", lastPacketTime).Int8("pck_idx", pck.Idx).Int8("stream_idx", videoStreamIdx).Msg("Current packet time < previous")
 				}
 			}
 			if streamVerboseLevel > VERBOSE_ADD {

--- a/mp4.go
+++ b/mp4.go
@@ -196,7 +196,9 @@ func processingMP4(
 				}
 				segmentCount++
 			} else {
-				// fmt.Println("Current packet time < previous ")
+				if streamVerboseLevel > VERBOSE_ADD {
+					log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_WRITE).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Dur("pck_time", pck.Time).Dur("prev_pck_time", lastPacketTime).Msg("Current packet time < previous")
+				}
 			}
 			if streamVerboseLevel > VERBOSE_ADD {
 				log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_CHAN_PACKET).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Wait other in archive channel")

--- a/mp4.go
+++ b/mp4.go
@@ -164,7 +164,7 @@ func processingMP4(
 				}
 				start = true
 				if segmentLength.Milliseconds() >= msPerSegment {
-					if streamVerboseLevel > VERBOSE_ADD {
+					if streamVerboseLevel > VERBOSE_NONE {
 						log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_SEGMENT_CUT).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Need to cut segment")
 					}
 					lastKeyFrame = pck

--- a/mp4.go
+++ b/mp4.go
@@ -149,6 +149,9 @@ func (app *Application) startMP4(archive *StreamArchiveWrapper, streamID uuid.UU
 		}
 
 		if archive.store.Type() == storage.STORAGE_MINIO {
+			if streamVerboseLevel > VERBOSE_ADD {
+				log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_WRITE).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Drop segment to minio")
+			}
 			_, err = outFile.Seek(0, io.SeekStart)
 			if err != nil {
 				log.Error().Err(err).Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_SAVE_MINIO).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Can't seek to the start of file")
@@ -174,13 +177,14 @@ func (app *Application) startMP4(archive *StreamArchiveWrapper, streamID uuid.UU
 			}
 		}
 
+		log.Info().Str("scope", SCOPE_ARCHIVE).Str("event", EVENT_ARCHIVE_CLOSE_FILE).Str("stream_id", streamID.String()).Str("segment_path", segmentPath).Int64("ms", archive.msPerSegment).Msg("Closing segment")
 		if err := outFile.Close(); err != nil {
 			log.Error().Err(err).Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_CLOSE).Str("stream_id", streamID.String()).Str("out_filename", outFile.Name()).Msg("Can't close file")
 			// @todo: handle?
 		}
 
 		lastSegmentTime = lastSegmentTime.Add(time.Since(st))
-		log.Info().Str("scope", SCOPE_ARCHIVE).Str("event", EVENT_ARCHIVE_CLOSE_FILE).Str("stream_id", streamID.String()).Str("segment_path", segmentPath).Int64("ms", archive.msPerSegment).Msg("Close segment")
+		log.Info().Str("scope", SCOPE_ARCHIVE).Str("event", EVENT_ARCHIVE_CLOSE_FILE).Str("stream_id", streamID.String()).Str("segment_path", segmentPath).Int64("ms", archive.msPerSegment).Msg("Closed segment")
 	}
 	return nil
 }

--- a/mp4.go
+++ b/mp4.go
@@ -232,7 +232,6 @@ func processingMP4(
 				if failureDuration > maxFailureDuration {
 					return lastKeyFrame, lastPacketTime, isConnected, failureDuration, ErrTimeFailure
 				}
-				continue
 			}
 			if streamVerboseLevel > VERBOSE_ADD {
 				log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_CHAN_PACKET).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Dur("pck_time", pck.Time).Dur("prev_pck_time", lastPacketTime).Dur("pck_dur", pck.Duration).Int8("pck_idx", pck.Idx).Int8("stream_idx", videoStreamIdx).Int("segment_count", segmentCount).Dur("segment_len", segmentLength).Msg("Wait other in archive channel")

--- a/mp4.go
+++ b/mp4.go
@@ -157,14 +157,6 @@ func (app *Application) startMP4(archive *StreamArchiveWrapper, streamID uuid.UU
 			if streamVerboseLevel > VERBOSE_ADD {
 				log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_WRITE).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Drop segment to minio")
 			}
-			// _, err = outFile.Seek(0, io.SeekStart)
-			// if err != nil {
-			// 	log.Error().Err(err).Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_SAVE_MINIO).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Can't seek to the start of file")
-			// 	return err
-			// }
-			// if streamVerboseLevel > VERBOSE_ADD {
-			// 	log.Info().Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_WRITE).Str("stream_id", streamID.String()).Str("segment_name", segmentName).Msg("Done seek to start of segment file")
-			// }
 			go func() {
 				st := time.Now()
 				outSegmentName, err := UploadToMinio(archive.store, segmentName, archive.bucket, segmentPath)
@@ -192,7 +184,6 @@ func (app *Application) startMP4(archive *StreamArchiveWrapper, streamID uuid.UU
 
 func UploadToMinio(minioStorage storage.ArchiveStorage, segmentName, bucket, sourceFileName string) (string, error) {
 	obj := storage.ArchiveUnit{
-		// Payload:     outFile,
 		SegmentName: segmentName,
 		Bucket:      bucket,
 		FileName:    sourceFileName,

--- a/mp4.go
+++ b/mp4.go
@@ -50,7 +50,7 @@ func (app *Application) startMP4(archive *StreamArchiveWrapper, streamID uuid.UU
 			if fileClosed {
 				return
 			}
-			log.Warn().Str("scope", SCOPE_APP).Str("event", EVENT_MP4_CLOSE).Str("stream_id", streamID.String()).Str("out_filename", outFile.Name()).Msg("File has not been closed in right order")
+			log.Warn().Str("scope", SCOPE_ARCHIVE).Str("event", EVENT_MP4_CLOSE).Str("stream_id", streamID.String()).Str("out_filename", outFile.Name()).Msg("File has not been closed in right order")
 			if err := file.Close(); err != nil {
 				log.Error().Err(err).Str("scope", SCOPE_MP4).Str("event", EVENT_MP4_CLOSE).Str("stream_id", streamID.String()).Str("out_filename", outFile.Name()).Msg("Can't close file")
 				// @todo: handle?

--- a/storage/archive_storage.go
+++ b/storage/archive_storage.go
@@ -2,11 +2,9 @@ package storage
 
 import (
 	"context"
-	"io"
 )
 
 type ArchiveUnit struct {
-	Payload     io.Reader
 	Bucket      string
 	SegmentName string
 	FileName    string

--- a/storage/archive_storage.go
+++ b/storage/archive_storage.go
@@ -9,6 +9,7 @@ type ArchiveUnit struct {
 	Payload     io.Reader
 	Bucket      string
 	SegmentName string
+	FileName    string
 }
 
 type ArchiveStorage interface {

--- a/storage/minio.go
+++ b/storage/minio.go
@@ -1,10 +1,8 @@
 package storage
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/lifecycle"
@@ -56,24 +54,6 @@ func (m *MinioProvider) UploadFile(ctx context.Context, object ArchiveUnit) (str
 	bucket := m.DefaultBucket
 	if object.Bucket != "" {
 		bucket = object.Bucket
-	}
-	if object.FileName == "" {
-		buf := &bytes.Buffer{}
-		size, err := io.Copy(buf, object.Payload)
-		if err != nil {
-			return "", err
-		}
-		_, err = m.client.PutObject(
-			ctx,
-			bucket,
-			fname,
-			buf,
-			size,
-			minio.PutObjectOptions{
-				ContentType: "application/octet-stream",
-			},
-		)
-		return object.SegmentName, err
 	}
 	_, err := m.client.FPutObject(
 		ctx,

--- a/storage/minio.go
+++ b/storage/minio.go
@@ -50,25 +50,36 @@ func (m *MinioProvider) MakeBucket(bucket string) error {
 	return nil
 }
 
+// UploadFile loads file to MinIO. Do not provide FileName field in ArchiveUnit object if you want to use Payload bytes; otherwise file will be loaded from filesystem by FileName field
 func (m *MinioProvider) UploadFile(ctx context.Context, object ArchiveUnit) (string, error) {
 	fname := fmt.Sprintf("%s/%s", m.Path, object.SegmentName)
-
-	buf := &bytes.Buffer{}
-
-	size, err := io.Copy(buf, object.Payload)
-	if err != nil {
-		return "", err
-	}
 	bucket := m.DefaultBucket
 	if object.Bucket != "" {
 		bucket = object.Bucket
 	}
-	_, err = m.client.PutObject(
+	if object.FileName == "" {
+		buf := &bytes.Buffer{}
+		size, err := io.Copy(buf, object.Payload)
+		if err != nil {
+			return "", err
+		}
+		_, err = m.client.PutObject(
+			ctx,
+			bucket,
+			fname,
+			buf,
+			size,
+			minio.PutObjectOptions{
+				ContentType: "application/octet-stream",
+			},
+		)
+		return object.SegmentName, err
+	}
+	_, err := m.client.FPutObject(
 		ctx,
 		bucket,
 		fname,
-		buf,
-		size,
+		object.FileName,
 		minio.PutObjectOptions{
 			ContentType: "application/octet-stream",
 		},

--- a/stream.go
+++ b/stream.go
@@ -36,7 +36,10 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 		if streamVerboseLevel > VERBOSE_NONE {
 			log.Info().Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_CODEC_MET).Str("stream_id", streamID.String()).Str("stream_url", url).Bool("hls_enabled", hlsEnabled).Any("codec_data", session.CodecData).Msg("Found codec. Adding this one")
 		}
-		app.Streams.AddCodecForStream(streamID, session.CodecData)
+		err = app.Streams.AddCodecForStream(streamID, session.CodecData)
+		if err != nil {
+			return errors.Wrapf(err, "Can't update codec data for stream %s on empty codecs", streamID)
+		}
 		if streamVerboseLevel > VERBOSE_NONE {
 			log.Info().Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_STATUS_UPDATE).Str("stream_id", streamID.String()).Str("stream_url", url).Bool("hls_enabled", hlsEnabled).Msg("Update stream status")
 		}
@@ -101,7 +104,10 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 				if streamVerboseLevel > VERBOSE_NONE {
 					log.Info().Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_CODEC_UPDATE_SIGNAL).Str("stream_id", streamID.String()).Str("stream_url", url).Any("codec_data", session.CodecData).Msg("Recieved update codec signal")
 				}
-				app.Streams.AddCodecForStream(streamID, session.CodecData)
+				err = app.Streams.AddCodecForStream(streamID, session.CodecData)
+				if err != nil {
+					return errors.Wrapf(err, "Can't update codec data for stream %s on codecs update signal", streamID)
+				}
 				err = app.Streams.UpdateStreamStatus(streamID, true)
 				if err != nil {
 					return errors.Wrapf(err, "Can't update status for stream %s after codecs update", streamID)

--- a/stream.go
+++ b/stream.go
@@ -28,6 +28,12 @@ const (
 // runStream runs RTSP grabbing process
 func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, archiveEnabled bool, streamVerboseLevel VerboseLevel) error {
 	var stopHlsCast, stopMP4Cast chan StopSignal
+	if hlsEnabled {
+		stopHlsCast = make(chan StopSignal, 1)
+	}
+	if archiveEnabled {
+		stopMP4Cast = make(chan StopSignal, 1)
+	}
 
 	if streamVerboseLevel > VERBOSE_NONE {
 		log.Info().Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_DIAL).Str("stream_id", streamID.String()).Str("stream_url", url).Bool("hls_enabled", hlsEnabled).Msg("Trying to dial")
@@ -86,7 +92,6 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 		if streamVerboseLevel > VERBOSE_NONE {
 			log.Info().Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_HLS_CAST).Str("stream_id", streamID.String()).Str("stream_url", url).Msg("Need to start casting for HLS")
 		}
-		stopHlsCast = make(chan StopSignal, 1)
 		err = app.startHlsCast(streamID, stopHlsCast)
 		if err != nil {
 			if streamVerboseLevel > VERBOSE_NONE {
@@ -103,7 +108,6 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 		if archive == nil {
 			log.Warn().Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_MP4_CAST).Str("stream_id", streamID.String()).Str("stream_url", url).Msg("Empty archive configuration for the given stream")
 		} else {
-			stopMP4Cast = make(chan StopSignal, 1)
 			err = app.startMP4Cast(archive, streamID, stopMP4Cast, streamVerboseLevel)
 			if err != nil {
 				if streamVerboseLevel > VERBOSE_NONE {

--- a/stream.go
+++ b/stream.go
@@ -158,6 +158,8 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 					return errors.Wrapf(err, "Can't update status for stream %s after RTP stops", streamID)
 				}
 				return errors.Wrapf(ErrStreamDisconnected, "URL is '%s'", url)
+			default:
+				log.Info().Str("warn", SCOPE_STREAMING).Str("event", EVENT_STREAMING_UNKNOWN_SIGNAL).Str("stream_id", streamID.String()).Str("stream_url", url).Int("signal", signals).Msg("Other signal")
 			}
 		case packetAV := <-session.OutgoingPacketQueue:
 			if streamVerboseLevel > VERBOSE_ADD {

--- a/stream.go
+++ b/stream.go
@@ -42,7 +42,7 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 		}
 		err = app.Streams.UpdateStreamStatus(streamID, true)
 		if err != nil {
-			return errors.Wrapf(err, "Can't update status for stream %s", streamID)
+			return errors.Wrapf(err, "Can't update status for stream %s on empty codecs", streamID)
 		}
 	}
 
@@ -104,7 +104,7 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 				app.Streams.AddCodecForStream(streamID, session.CodecData)
 				err = app.Streams.UpdateStreamStatus(streamID, true)
 				if err != nil {
-					return errors.Wrapf(err, "Can't update status for stream %s", streamID)
+					return errors.Wrapf(err, "Can't update status for stream %s after codecs update", streamID)
 				}
 			case rtspv2.SignalStreamRTPStop:
 				if streamVerboseLevel > VERBOSE_NONE {
@@ -112,7 +112,7 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 				}
 				err = app.Streams.UpdateStreamStatus(streamID, false)
 				if err != nil {
-					errors.Wrapf(err, "Can't switch status to False for stream '%s'", url)
+					return errors.Wrapf(err, "Can't update status for stream %s after RTP stops", streamID)
 				}
 				return errors.Wrapf(ErrStreamDisconnected, "URL is '%s'", url)
 			}
@@ -145,7 +145,7 @@ func (app *Application) runStream(streamID uuid.UUID, url string, hlsEnabled, ar
 				}
 				errStatus := app.Streams.UpdateStreamStatus(streamID, false)
 				if errStatus != nil {
-					errors.Wrapf(errors.Wrapf(err, "Can't cast packet %s (%s)", streamID, url), "Can't switch status to False for stream '%s'", url)
+					return errors.Wrapf(err, "Can't update status for stream %s after casting", streamID)
 				}
 				return errors.Wrapf(err, "Can't cast packet %s (%s)", streamID, url)
 			}

--- a/stream_hls.go
+++ b/stream_hls.go
@@ -7,9 +7,6 @@ import (
 )
 
 func (app *Application) startHlsCast(streamID uuid.UUID, stopCast chan StopSignal) error {
-	if RWMutexLocked(&app.Streams.RWMutex) {
-		log.Warn().Str("fn", "startHlsCast").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	app.Streams.Lock()
 	defer app.Streams.Unlock()
 	stream, ok := app.Streams.store[streamID]

--- a/stream_hls.go
+++ b/stream_hls.go
@@ -1,0 +1,26 @@
+package videoserver
+
+import (
+	"github.com/deepch/vdk/av"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+func (app *Application) startHlsCast(streamID uuid.UUID, stopCast chan StopSignal) error {
+	if RWMutexLocked(&app.Streams.RWMutex) {
+		log.Warn().Str("fn", "startHlsCast").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
+	app.Streams.Lock()
+	defer app.Streams.Unlock()
+	stream, ok := app.Streams.store[streamID]
+	if !ok {
+		return ErrStreamNotFound
+	}
+	go func(id uuid.UUID, hlsChanel chan av.Packet, stop chan StopSignal) {
+		err := app.startHls(id, hlsChanel, stop)
+		if err != nil {
+			log.Error().Err(err).Str("scope", SCOPE_HLS).Str("event", EVENT_HLS_START_CAST).Str("stream_id", id.String()).Msg("Error on HLS cast start")
+		}
+	}(streamID, stream.hlsChanel, stopCast)
+	return nil
+}

--- a/stream_mp4.go
+++ b/stream_mp4.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uuid.UUID, stopCast chan StopSignal, streamVerboseLevel VerboseLevel) error {
+func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uuid.UUID, stopCast chan StopSignal, errorSignal chan error, streamVerboseLevel VerboseLevel) error {
 	if archive == nil {
 		return ErrNullArchive
 	}
@@ -22,6 +22,7 @@ func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uui
 		if err != nil {
 			log.Error().Err(err).Str("scope", SCOPE_ARCHIVE).Str("event", EVENT_ARCHIVE_START_CAST).Str("stream_id", id.String()).Msg("Error on MP4 cast start")
 		}
+		errorSignal <- err
 	}(archive, streamID, channel, stopCast, streamVerboseLevel)
 	return nil
 }

--- a/stream_mp4.go
+++ b/stream_mp4.go
@@ -10,9 +10,6 @@ func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uui
 	if archive == nil {
 		return ErrNullArchive
 	}
-	if RWMutexLocked(&app.Streams.RWMutex) {
-		log.Warn().Str("fn", "startMP4Cast").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	app.Streams.Lock()
 	defer app.Streams.Unlock()
 	stream, ok := app.Streams.store[streamID]

--- a/stream_mp4.go
+++ b/stream_mp4.go
@@ -1,0 +1,30 @@
+package videoserver
+
+import (
+	"github.com/deepch/vdk/av"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+func (app *Application) startMP4Cast(archive *StreamArchiveWrapper, streamID uuid.UUID, stopCast chan StopSignal, streamVerboseLevel VerboseLevel) error {
+	if archive == nil {
+		return ErrNullArchive
+	}
+	if RWMutexLocked(&app.Streams.RWMutex) {
+		log.Warn().Str("fn", "startMP4Cast").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
+	app.Streams.Lock()
+	defer app.Streams.Unlock()
+	stream, ok := app.Streams.store[streamID]
+	if !ok {
+		return ErrStreamNotFound
+	}
+	channel := stream.mp4Chanel
+	go func(arch *StreamArchiveWrapper, id uuid.UUID, mp4Chanel chan av.Packet, stop chan StopSignal, verbose VerboseLevel) {
+		err := app.startMP4(arch, id, mp4Chanel, stop, verbose)
+		if err != nil {
+			log.Error().Err(err).Str("scope", SCOPE_ARCHIVE).Str("event", EVENT_ARCHIVE_START_CAST).Str("stream_id", id.String()).Msg("Error on MP4 cast start")
+		}
+	}(archive, streamID, channel, stopCast, streamVerboseLevel)
+	return nil
+}

--- a/streams.go
+++ b/streams.go
@@ -17,18 +17,13 @@ const (
 func (app *Application) StartStreams() {
 	streamsIDs := app.Streams.GetAllStreamsIDS()
 	for i := range streamsIDs {
-		app.StartStream(streamsIDs[i])
+		go func(id uuid.UUID) {
+			err := app.RunStream(context.Background(), id)
+			if err != nil {
+				log.Error().Err(err).Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_RUN).Str("stream_id", id.String()).Msg("Error on stream runner")
+			}
+		}(streamsIDs[i])
 	}
-}
-
-// StartStream starts single video stream
-func (app *Application) StartStream(streamID uuid.UUID) {
-	go func(id uuid.UUID) {
-		err := app.RunStream(context.Background(), id)
-		if err != nil {
-			log.Error().Err(err).Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_RUN).Str("stream_id", id.String()).Msg("Error on stream runner")
-		}
-	}(streamID)
 }
 
 func (app *Application) RunStream(ctx context.Context, streamID uuid.UUID) error {

--- a/streams.go
+++ b/streams.go
@@ -17,13 +17,18 @@ const (
 func (app *Application) StartStreams() {
 	streamsIDs := app.Streams.GetAllStreamsIDS()
 	for i := range streamsIDs {
-		go func(id uuid.UUID) {
-			err := app.RunStream(context.Background(), id)
-			if err != nil {
-				log.Error().Err(err).Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_RUN).Str("stream_id", id.String()).Msg("Error on stream runner")
-			}
-		}(streamsIDs[i])
+		app.StartStream(streamsIDs[i])
 	}
+}
+
+// StartStream starts single video stream
+func (app *Application) StartStream(streamID uuid.UUID) {
+	go func(id uuid.UUID) {
+		err := app.RunStream(context.Background(), id)
+		if err != nil {
+			log.Error().Err(err).Str("scope", SCOPE_STREAMING).Str("event", EVENT_STREAMING_RUN).Str("stream_id", id.String()).Msg("Error on stream runner")
+		}
+	}(streamID)
 }
 
 func (app *Application) RunStream(ctx context.Context, streamID uuid.UUID) error {

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -24,6 +24,9 @@ func NewStreamsStorageDefault() StreamsStorage {
 
 // GetStreamInfo returns stream URL and its supported output types
 func (streams *StreamsStorage) GetStreamInfo(streamID uuid.UUID) (string, []StreamType) {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "GetStreamInfo").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -35,6 +38,9 @@ func (streams *StreamsStorage) GetStreamInfo(streamID uuid.UUID) (string, []Stre
 
 // GetAllStreamsIDS returns all storage streams' keys as slice
 func (streams *StreamsStorage) GetAllStreamsIDS() []uuid.UUID {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "GetAllStreamsIDS").Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	keys := make([]uuid.UUID, 0, len(streams.store))
@@ -46,6 +52,9 @@ func (streams *StreamsStorage) GetAllStreamsIDS() []uuid.UUID {
 
 // StreamExists checks whenever given stream ID exists in storage
 func (streams *StreamsStorage) StreamExists(streamID uuid.UUID) bool {
+	if RWMutexRLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "StreamExists").Str("stream_id", streamID.String()).Msg("RLocked already")
+	}
 	streams.RLock()
 	defer streams.RUnlock()
 	_, ok := streams.store[streamID]
@@ -54,6 +63,9 @@ func (streams *StreamsStorage) StreamExists(streamID uuid.UUID) bool {
 
 // TypeExistsForStream checks whenever specific stream ID supports then given output stream type
 func (streams *StreamsStorage) TypeExistsForStream(streamID uuid.UUID, streamType StreamType) bool {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "TypeExistsForStream").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -67,6 +79,9 @@ func (streams *StreamsStorage) TypeExistsForStream(streamID uuid.UUID, streamTyp
 
 // AddCodecForStream appends new codecs data for the given stream
 func (streams *StreamsStorage) AddCodecForStream(streamID uuid.UUID, codecs []av.CodecData) error {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "AddCodecForStream").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -82,6 +97,9 @@ func (streams *StreamsStorage) AddCodecForStream(streamID uuid.UUID, codecs []av
 
 // GetCodecsDataForStream returns COPY of codecs data for the given stream
 func (streams *StreamsStorage) GetCodecsDataForStream(streamID uuid.UUID) ([]av.CodecData, error) {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "GetCodecsDataForStream").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -102,6 +120,9 @@ func (streams *StreamsStorage) GetCodecsDataForStream(streamID uuid.UUID) ([]av.
 
 // UpdateStreamStatus sets new status value for the given stream
 func (streams *StreamsStorage) UpdateStreamStatus(streamID uuid.UUID, status bool) error {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "UpdateStreamStatus").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -117,6 +138,9 @@ func (streams *StreamsStorage) UpdateStreamStatus(streamID uuid.UUID, status boo
 
 // AddViewer adds client to the given stream. Return newly client ID, buffered channel for stream on success
 func (streams *StreamsStorage) AddViewer(streamID uuid.UUID) (uuid.UUID, chan av.Packet, error) {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "AddViewer").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -137,6 +161,9 @@ func (streams *StreamsStorage) AddViewer(streamID uuid.UUID) (uuid.UUID, chan av
 
 // DeleteViewer removes given client from the stream
 func (streams *StreamsStorage) DeleteViewer(streamID, clientID uuid.UUID) {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "DeleteViewer").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -151,6 +178,9 @@ func (streams *StreamsStorage) DeleteViewer(streamID, clientID uuid.UUID) {
 
 // CastPacket cast AV Packet to viewers and possible to HLS/MP4 channels
 func (streams *StreamsStorage) CastPacket(streamID uuid.UUID, pck av.Packet, hlsEnabled, archiveEnabled bool) error {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "CastPacket").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	stream, ok := streams.store[streamID]
 	if !ok {
@@ -189,6 +219,9 @@ func (streams *StreamsStorage) CastPacket(streamID uuid.UUID, pck av.Packet, hls
 
 // GetVerboseLevelForStream returst verbose level for the given stream
 func (streams *StreamsStorage) GetVerboseLevelForStream(streamID uuid.UUID) VerboseLevel {
+	if RWMutexRLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "GetVerboseLevelForStream").Str("stream_id", streamID.String()).Msg("RLocked already")
+	}
 	streams.RLock()
 	defer streams.RUnlock()
 	stream, ok := streams.store[streamID]
@@ -200,6 +233,9 @@ func (streams *StreamsStorage) GetVerboseLevelForStream(streamID uuid.UUID) Verb
 
 // IsArchiveEnabledForStream returns whenever archive has been enabled for stream
 func (streams *StreamsStorage) IsArchiveEnabledForStream(streamID uuid.UUID) (bool, error) {
+	if RWMutexRLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "IsArchiveEnabledForStream").Str("stream_id", streamID.String()).Msg("RLocked already")
+	}
 	streams.RLock()
 	defer streams.RUnlock()
 	stream, ok := streams.store[streamID]
@@ -211,6 +247,9 @@ func (streams *StreamsStorage) IsArchiveEnabledForStream(streamID uuid.UUID) (bo
 
 // UpdateArchiveStorageForStream updates archive storage configuration (it override existing one!)
 func (streams *StreamsStorage) UpdateArchiveStorageForStream(streamID uuid.UUID, archiveStorage *StreamArchiveWrapper) error {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "UpdateArchiveStorageForStream").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -223,6 +262,9 @@ func (streams *StreamsStorage) UpdateArchiveStorageForStream(streamID uuid.UUID,
 
 // GetStreamArchiveStorage returns pointer to the archive storage for the given stream
 func (streams *StreamsStorage) GetStreamArchiveStorage(streamID uuid.UUID) *StreamArchiveWrapper {
+	if RWMutexLocked(&streams.RWMutex) {
+		log.Warn().Str("fn", "GetStreamArchiveStorage").Str("stream_id", streamID.String()).Msg("Locked already")
+	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -66,17 +66,18 @@ func (streams *StreamsStorage) TypeExistsForStream(streamID uuid.UUID, streamTyp
 }
 
 // AddCodecForStream appends new codecs data for the given stream
-func (streams *StreamsStorage) AddCodecForStream(streamID uuid.UUID, codecs []av.CodecData) {
+func (streams *StreamsStorage) AddCodecForStream(streamID uuid.UUID, codecs []av.CodecData) error {
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
 	if !ok {
-		return
+		return ErrStreamNotFound
 	}
 	stream.Codecs = codecs
 	if stream.verboseLevel > VERBOSE_SIMPLE {
 		log.Info().Str("scope", SCOPE_STREAM).Str("event", EVENT_STREAM_CODEC_ADD).Str("stream_id", streamID.String()).Any("codec_data", codecs).Msg("Add codec")
 	}
+	return nil
 }
 
 // GetCodecsDataForStream returns COPY of codecs data for the given stream

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -153,6 +153,7 @@ func (streams *StreamsStorage) CastPacket(streamID uuid.UUID, pck av.Packet, hls
 	streams.Lock()
 	stream, ok := streams.store[streamID]
 	if !ok {
+		streams.Unlock()
 		return ErrStreamNotFound
 	}
 	streams.Unlock()

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -46,8 +46,8 @@ func (streams *StreamsStorage) GetAllStreamsIDS() []uuid.UUID {
 
 // StreamExists checks whenever given stream ID exists in storage
 func (streams *StreamsStorage) StreamExists(streamID uuid.UUID) bool {
-	streams.RLock()
-	defer streams.RUnlock()
+	streams.Lock()
+	defer streams.Unlock()
 	_, ok := streams.store[streamID]
 	return ok
 }
@@ -187,8 +187,8 @@ func (streams *StreamsStorage) CastPacket(streamID uuid.UUID, pck av.Packet, hls
 
 // GetVerboseLevelForStream returst verbose level for the given stream
 func (streams *StreamsStorage) GetVerboseLevelForStream(streamID uuid.UUID) VerboseLevel {
-	streams.RLock()
-	defer streams.RUnlock()
+	streams.Lock()
+	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
 	if !ok {
 		return VERBOSE_NONE
@@ -198,8 +198,8 @@ func (streams *StreamsStorage) GetVerboseLevelForStream(streamID uuid.UUID) Verb
 
 // IsArchiveEnabledForStream returns whenever archive has been enabled for stream
 func (streams *StreamsStorage) IsArchiveEnabledForStream(streamID uuid.UUID) (bool, error) {
-	streams.RLock()
-	defer streams.RUnlock()
+	streams.Lock()
+	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
 	if !ok {
 		return false, ErrStreamNotFound

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -46,8 +46,8 @@ func (streams *StreamsStorage) GetAllStreamsIDS() []uuid.UUID {
 
 // StreamExists checks whenever given stream ID exists in storage
 func (streams *StreamsStorage) StreamExists(streamID uuid.UUID) bool {
-	streams.Lock()
-	defer streams.Unlock()
+	streams.RLock()
+	defer streams.RUnlock()
 	_, ok := streams.store[streamID]
 	return ok
 }
@@ -187,8 +187,8 @@ func (streams *StreamsStorage) CastPacket(streamID uuid.UUID, pck av.Packet, hls
 
 // GetVerboseLevelForStream returst verbose level for the given stream
 func (streams *StreamsStorage) GetVerboseLevelForStream(streamID uuid.UUID) VerboseLevel {
-	streams.Lock()
-	defer streams.Unlock()
+	streams.RLock()
+	defer streams.RUnlock()
 	stream, ok := streams.store[streamID]
 	if !ok {
 		return VERBOSE_NONE

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -198,8 +198,8 @@ func (streams *StreamsStorage) GetVerboseLevelForStream(streamID uuid.UUID) Verb
 
 // IsArchiveEnabledForStream returns whenever archive has been enabled for stream
 func (streams *StreamsStorage) IsArchiveEnabledForStream(streamID uuid.UUID) (bool, error) {
-	streams.Lock()
-	defer streams.Unlock()
+	streams.RLock()
+	defer streams.RUnlock()
 	stream, ok := streams.store[streamID]
 	if !ok {
 		return false, ErrStreamNotFound

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -24,9 +24,6 @@ func NewStreamsStorageDefault() StreamsStorage {
 
 // GetStreamInfo returns stream URL and its supported output types
 func (streams *StreamsStorage) GetStreamInfo(streamID uuid.UUID) (string, []StreamType) {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "GetStreamInfo").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -38,9 +35,6 @@ func (streams *StreamsStorage) GetStreamInfo(streamID uuid.UUID) (string, []Stre
 
 // GetAllStreamsIDS returns all storage streams' keys as slice
 func (streams *StreamsStorage) GetAllStreamsIDS() []uuid.UUID {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "GetAllStreamsIDS").Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	keys := make([]uuid.UUID, 0, len(streams.store))
@@ -52,9 +46,6 @@ func (streams *StreamsStorage) GetAllStreamsIDS() []uuid.UUID {
 
 // StreamExists checks whenever given stream ID exists in storage
 func (streams *StreamsStorage) StreamExists(streamID uuid.UUID) bool {
-	if RWMutexRLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "StreamExists").Str("stream_id", streamID.String()).Msg("RLocked already")
-	}
 	streams.RLock()
 	defer streams.RUnlock()
 	_, ok := streams.store[streamID]
@@ -63,9 +54,6 @@ func (streams *StreamsStorage) StreamExists(streamID uuid.UUID) bool {
 
 // TypeExistsForStream checks whenever specific stream ID supports then given output stream type
 func (streams *StreamsStorage) TypeExistsForStream(streamID uuid.UUID, streamType StreamType) bool {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "TypeExistsForStream").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -79,9 +67,6 @@ func (streams *StreamsStorage) TypeExistsForStream(streamID uuid.UUID, streamTyp
 
 // AddCodecForStream appends new codecs data for the given stream
 func (streams *StreamsStorage) AddCodecForStream(streamID uuid.UUID, codecs []av.CodecData) error {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "AddCodecForStream").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -97,9 +82,6 @@ func (streams *StreamsStorage) AddCodecForStream(streamID uuid.UUID, codecs []av
 
 // GetCodecsDataForStream returns COPY of codecs data for the given stream
 func (streams *StreamsStorage) GetCodecsDataForStream(streamID uuid.UUID) ([]av.CodecData, error) {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "GetCodecsDataForStream").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -120,9 +102,6 @@ func (streams *StreamsStorage) GetCodecsDataForStream(streamID uuid.UUID) ([]av.
 
 // UpdateStreamStatus sets new status value for the given stream
 func (streams *StreamsStorage) UpdateStreamStatus(streamID uuid.UUID, status bool) error {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "UpdateStreamStatus").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -138,9 +117,6 @@ func (streams *StreamsStorage) UpdateStreamStatus(streamID uuid.UUID, status boo
 
 // AddViewer adds client to the given stream. Return newly client ID, buffered channel for stream on success
 func (streams *StreamsStorage) AddViewer(streamID uuid.UUID) (uuid.UUID, chan av.Packet, error) {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "AddViewer").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -161,9 +137,6 @@ func (streams *StreamsStorage) AddViewer(streamID uuid.UUID) (uuid.UUID, chan av
 
 // DeleteViewer removes given client from the stream
 func (streams *StreamsStorage) DeleteViewer(streamID, clientID uuid.UUID) {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "DeleteViewer").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -178,9 +151,6 @@ func (streams *StreamsStorage) DeleteViewer(streamID, clientID uuid.UUID) {
 
 // CastPacket cast AV Packet to viewers and possible to HLS/MP4 channels
 func (streams *StreamsStorage) CastPacket(streamID uuid.UUID, pck av.Packet, hlsEnabled, archiveEnabled bool) error {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "CastPacket").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	stream, ok := streams.store[streamID]
 	if !ok {
@@ -219,9 +189,6 @@ func (streams *StreamsStorage) CastPacket(streamID uuid.UUID, pck av.Packet, hls
 
 // GetVerboseLevelForStream returst verbose level for the given stream
 func (streams *StreamsStorage) GetVerboseLevelForStream(streamID uuid.UUID) VerboseLevel {
-	if RWMutexRLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "GetVerboseLevelForStream").Str("stream_id", streamID.String()).Msg("RLocked already")
-	}
 	streams.RLock()
 	defer streams.RUnlock()
 	stream, ok := streams.store[streamID]
@@ -233,9 +200,6 @@ func (streams *StreamsStorage) GetVerboseLevelForStream(streamID uuid.UUID) Verb
 
 // IsArchiveEnabledForStream returns whenever archive has been enabled for stream
 func (streams *StreamsStorage) IsArchiveEnabledForStream(streamID uuid.UUID) (bool, error) {
-	if RWMutexRLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "IsArchiveEnabledForStream").Str("stream_id", streamID.String()).Msg("RLocked already")
-	}
 	streams.RLock()
 	defer streams.RUnlock()
 	stream, ok := streams.store[streamID]
@@ -247,9 +211,6 @@ func (streams *StreamsStorage) IsArchiveEnabledForStream(streamID uuid.UUID) (bo
 
 // UpdateArchiveStorageForStream updates archive storage configuration (it override existing one!)
 func (streams *StreamsStorage) UpdateArchiveStorageForStream(streamID uuid.UUID, archiveStorage *StreamArchiveWrapper) error {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "UpdateArchiveStorageForStream").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
@@ -262,9 +223,6 @@ func (streams *StreamsStorage) UpdateArchiveStorageForStream(streamID uuid.UUID,
 
 // GetStreamArchiveStorage returns pointer to the archive storage for the given stream
 func (streams *StreamsStorage) GetStreamArchiveStorage(streamID uuid.UUID) *StreamArchiveWrapper {
-	if RWMutexLocked(&streams.RWMutex) {
-		log.Warn().Str("fn", "GetStreamArchiveStorage").Str("stream_id", streamID.String()).Msg("Locked already")
-	}
 	streams.Lock()
 	defer streams.Unlock()
 	stream, ok := streams.store[streamID]

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -151,11 +151,11 @@ func (streams *StreamsStorage) DeleteViewer(streamID, clientID uuid.UUID) {
 // CastPacket cast AV Packet to viewers and possible to HLS/MP4 channels
 func (streams *StreamsStorage) CastPacket(streamID uuid.UUID, pck av.Packet, hlsEnabled, archiveEnabled bool) error {
 	streams.Lock()
-	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
 	if !ok {
 		return ErrStreamNotFound
 	}
+	streams.Unlock()
 	if stream.verboseLevel > VERBOSE_ADD {
 		log.Info().Str("scope", SCOPE_STREAM).Str("event", EVENT_STREAM_CAST_PACKET).Str("stream_id", streamID.String()).Bool("hls_enabled", hlsEnabled).Bool("archive_enabled", stream.archive != nil).Int("clients_num", len(stream.Clients)).Msg("Cast packet")
 	}

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -209,8 +209,8 @@ func (streams *StreamsStorage) IsArchiveEnabledForStream(streamID uuid.UUID) (bo
 
 // UpdateArchiveStorageForStream updates archive storage configuration (it override existing one!)
 func (streams *StreamsStorage) UpdateArchiveStorageForStream(streamID uuid.UUID, archiveStorage *StreamArchiveWrapper) error {
-	streams.RLock()
-	defer streams.RUnlock()
+	streams.Lock()
+	defer streams.Unlock()
 	stream, ok := streams.store[streamID]
 	if !ok {
 		return ErrStreamNotFound

--- a/streams_storage.go
+++ b/streams_storage.go
@@ -209,8 +209,8 @@ func (streams *StreamsStorage) IsArchiveEnabledForStream(streamID uuid.UUID) (bo
 
 // UpdateArchiveStorageForStream updates archive storage configuration (it override existing one!)
 func (streams *StreamsStorage) UpdateArchiveStorageForStream(streamID uuid.UUID, archiveStorage *StreamArchiveWrapper) error {
-	streams.Lock()
-	defer streams.Unlock()
+	streams.RLock()
+	defer streams.RUnlock()
 	stream, ok := streams.store[streamID]
 	if !ok {
 		return ErrStreamNotFound


### PR DESCRIPTION
Trying to solve #46 
- Remove `defer streams.Unlock()` in CastPacket function - **related to bug**, since `defer` never called if channel is full and can't accept packet
- Send files into the MinIO in separate goroutine
- Remove `goto` usage
- Replace boolean type signal for stopping process with custom type
- Restart loop on stream error
- Update `lastPacketTime` despite of bad packet time